### PR TITLE
Add `"custom"` option to `flexdog()`

### DIFF
--- a/man/flex_update_pivec.Rd
+++ b/man/flex_update_pivec.Rd
@@ -5,7 +5,8 @@
 \title{Update the distribution of genotypes from various models.}
 \usage{
 flex_update_pivec(weight_vec, model = c("hw", "bb", "norm", "ash", "f1",
-  "s1", "f1pp", "s1pp", "f1ppdr", "s1ppdr", "flex", "uniform"), control)
+  "s1", "f1pp", "s1pp", "f1ppdr", "s1ppdr", "flex", "uniform", "custom"),
+  control)
 }
 \arguments{
 \item{weight_vec}{\code{colSums(wik_mat)} from \code{\link{flexdog}}.

--- a/man/flexdog.Rd
+++ b/man/flexdog.Rd
@@ -5,10 +5,10 @@
 \title{Flexible genotyping for polyploids from next-generation sequencing data.}
 \usage{
 flexdog(refvec, sizevec, ploidy, model = c("norm", "hw", "bb", "ash",
-  "s1", "s1pp", "f1", "f1pp", "flex", "uniform"), p1ref = NULL,
+  "s1", "s1pp", "f1", "f1pp", "flex", "uniform", "custom"), p1ref = NULL,
   p1size = NULL, p2ref = NULL, p2size = NULL, snpname = NULL,
   bias_init = exp(c(-1, -0.5, 0, 0.5, 1)), verbose = TRUE,
-  outliers = FALSE, ...)
+  outliers = FALSE, prior_vec = NULL, ...)
 }
 \arguments{
 \item{refvec}{A vector of counts of reads of the reference allele.}
@@ -48,6 +48,11 @@ over the multiple runs of \code{flexdog_full}.}
 (\code{TRUE}) or not (\code{FALSE}). Only supported when
 \code{model = "f1"} or \code{model = "s1"}. I wouldn't
 recommend it for any other model anyway.}
+
+\item{prior_vec}{The pre-specified genotype distribution. Only used if
+\code{model = "custom"} and must otherwise be \code{NULL}. If specified,
+then it should be a vector of length \code{ploidy + 1} with
+non-negative elements that sum to 1.}
 
 \item{...}{Additional parameters to pass to \code{\link{flexdog_full}}.}
 }
@@ -102,6 +107,7 @@ An object of class \code{flexdog}, which consists
           \code{get_bivalent_probs(ploidy)$probmat[get_bivalent_probs(ploidy)$lvec == p2geno, , drop = FALSE]}.}
       \item{\code{model = "flex"}:}{\code{par} is an empty list.}
       \item{\code{model = "uniform"}:}{\code{par} is an empty list.}
+      \item{\code{model = "custom"}:}{\code{par} is an empty list.}
       }}
   \item{\code{geno}}{The posterior mode genotype. These are your
       genotype estimates.}
@@ -188,6 +194,9 @@ Possible values of the genotype distribution (values of \code{model}) are:
       be less robust to violations in modeling assumptions.}
   \item{\code{"uniform"}}{A discrete uniform distribution. This should never
       be used in practice.}
+  \item{\code{"custom"}}{A pre-specified prior distribution. You specify
+      it using the \code{prior_vec} argument. You should almost never
+      use this option in practice.}
 }
 
 You might think a good default is \code{model = "uniform"} because it is

--- a/man/flexdog_full.Rd
+++ b/man/flexdog_full.Rd
@@ -5,13 +5,14 @@
 \title{Flexible genotyping for polyploids from next-generation sequencing data.}
 \usage{
 flexdog_full(refvec, sizevec, ploidy, model = c("norm", "hw", "bb",
-  "ash", "s1", "s1pp", "f1", "f1pp", "flex", "uniform"), verbose = TRUE,
-  mean_bias = 0, var_bias = 0.7^2, mean_seq = -4.7, var_seq = 1,
-  seq = 0.005, bias = 1, od = 0.001, update_bias = TRUE,
-  update_seq = TRUE, update_od = TRUE, mode = NULL,
-  use_cvxr = FALSE, itermax = 200, tol = 10^-4, fs1_alpha = 10^-3,
-  ashpen = 10^-6, p1ref = NULL, p1size = NULL, p2ref = NULL,
-  p2size = NULL, snpname = NULL, outliers = FALSE)
+  "ash", "s1", "s1pp", "f1", "f1pp", "flex", "uniform", "custom"),
+  verbose = TRUE, mean_bias = 0, var_bias = 0.7^2, mean_seq = -4.7,
+  var_seq = 1, seq = 0.005, bias = 1, od = 0.001,
+  update_bias = TRUE, update_seq = TRUE, update_od = TRUE,
+  mode = NULL, use_cvxr = FALSE, itermax = 200, tol = 10^-4,
+  fs1_alpha = 10^-3, ashpen = 10^-6, p1ref = NULL, p1size = NULL,
+  p2ref = NULL, p2size = NULL, snpname = NULL, outliers = FALSE,
+  prior_vec = NULL)
 }
 \arguments{
 \item{refvec}{A vector of counts of reads of the reference allele.}
@@ -104,6 +105,11 @@ This is just returned in the \code{input} list for your reference.}
 (\code{TRUE}) or not (\code{FALSE}). Only supported when
 \code{model = "f1"} or \code{model = "s1"}. I wouldn't
 recommend it for any other model anyway.}
+
+\item{prior_vec}{The pre-specified genotype distribution. Only used if
+\code{model = "custom"} and must otherwise be \code{NULL}. If specified,
+then it should be a vector of length \code{ploidy + 1} with
+non-negative elements that sum to 1.}
 }
 \value{
 An object of class \code{flexdog}, which consists
@@ -156,6 +162,7 @@ An object of class \code{flexdog}, which consists
           \code{get_bivalent_probs(ploidy)$probmat[get_bivalent_probs(ploidy)$lvec == p2geno, , drop = FALSE]}.}
       \item{\code{model = "flex"}:}{\code{par} is an empty list.}
       \item{\code{model = "uniform"}:}{\code{par} is an empty list.}
+      \item{\code{model = "custom"}:}{\code{par} is an empty list.}
       }}
   \item{\code{geno}}{The posterior mode genotype. These are your
       genotype estimates.}
@@ -243,6 +250,9 @@ Possible values of the genotype distribution (values of \code{model}) are:
       be less robust to violations in modeling assumptions.}
   \item{\code{"uniform"}}{A discrete uniform distribution. This should never
       be used in practice.}
+  \item{\code{"custom"}}{A pre-specified prior distribution. You specify
+      it using the \code{prior_vec} argument. You should almost never
+      use this option in practice.}
 }
 
 You might think a good default is \code{model = "uniform"} because it is

--- a/man/initialize_pivec.Rd
+++ b/man/initialize_pivec.Rd
@@ -5,7 +5,7 @@
 \title{Initialize \code{pivec} for \code{\link{flexdog}} EM algorithm.}
 \usage{
 initialize_pivec(ploidy, mode, model = c("hw", "bb", "norm", "ash", "f1",
-  "s1", "f1pp", "s1pp", "f1ppdr", "s1ppdr", "flex", "uniform"))
+  "s1", "f1pp", "s1pp", "f1ppdr", "s1ppdr", "flex", "uniform", "custom"))
 }
 \arguments{
 \item{ploidy}{The ploidy of the species. Assumed to be the same for each

--- a/src/flexdog.cpp
+++ b/src/flexdog.cpp
@@ -20,7 +20,7 @@ NumericVector get_probk_vec(NumericVector pivec, std::string model, double mode)
   NumericVector probk_vec(K + 1);
   if ((model == "flex") | (model == "hw") | (model == "f1") | (model == "s1") | (model == "uniform") |
     (model == "bb") | (model == "norm") | (model == "f1pp") | (model == "s1pp") |
-    (model == "f1ppdr") | (model == "s1ppdr")) {
+    (model == "f1ppdr") | (model == "s1ppdr") | (model == "custom")) {
     probk_vec = pivec;
   } else if (model == "ash") {
     double denom; // what you divide the pi's by.
@@ -42,7 +42,7 @@ NumericVector get_probk_vec(NumericVector pivec, std::string model, double mode)
       }
     }
   } else {
-    Rcpp::stop("get_probk_vec: model must be one of 'flex', 'ash', 'hw', 'bb', 'norm', 'f1', 's1', 'f1pp', 's1pp', 'f1ppdr', 's1ppdr', or 'uniform'");
+    Rcpp::stop("get_probk_vec: model must be one of 'flex', 'ash', 'hw', 'bb', 'norm', 'f1', 's1', 'f1pp', 's1pp', 'f1ppdr', 's1ppdr', 'uniform', or 'custom'");
   }
   return probk_vec;
 }

--- a/tests/testthat/test_flexdog.R
+++ b/tests/testthat/test_flexdog.R
@@ -71,6 +71,14 @@ test_that("flexdog works", {
   fout <- flexdog(refvec = refvec, sizevec = sizevec,
                   p1ref = 10, p1size = 20,
                   ploidy = ploidy, model = "s1pp", verbose = FALSE)
+
+  flexdog(refvec = refvec,
+          sizevec = sizevec,
+          ploidy = ploidy,
+          model = "custom",
+          bias = 1,
+          prior_vec = 0:ploidy / sum(0:ploidy),
+          verbose = FALSE) -> fout
 }
 )
 


### PR DESCRIPTION
This allows users to specify the genotype distribution. This feature is only useful for educational purposes, not for practical data analysis.